### PR TITLE
Switch OCI image to ROCK

### DIFF
--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -48,4 +48,4 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: 3.11/edge
+          channel: 3.9/edge

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   rabbitmq-image:
     type: oci-image
     description: OCI image for rabbitmq
-    upstream-source: docker.io/rabbitmq:3.11.3-management
+    upstream-source: ghcr.io/openstack-snaps/rabbitmq:3.9.13
 
 storage:
   rabbitmq-data:


### PR DESCRIPTION
Updated `upstream-source` metadata to the new ROCK based OCI image.