### PR TITLE
logging: log to console

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -239,6 +239,10 @@ class RabbitMQOperatorCharm(CharmBase):
 
     def _rabbitmq_layer(self) -> dict:
         """Pebble layer definition for RabbitMQ."""
+        # NOTE(jamespage)
+        # Use the full path to the rabbitmq-server binary
+        # rather than the helper wrapper script to avoid
+        # redirection of console output to a log file.
         return {
             "summary": "RabbitMQ layer",
             "description": "pebble config layer for RabbitMQ",
@@ -246,7 +250,7 @@ class RabbitMQOperatorCharm(CharmBase):
                 RABBITMQ_SERVICE: {
                     "override": "replace",
                     "summary": "RabbitMQ Server",
-                    "command": "rabbitmq-server",
+                    "command": "/usr/lib/rabbitmq/bin/rabbitmq-server",
                     "startup": "enabled",
                     "user": RABBITMQ_USER,
                     "group": RABBITMQ_GROUP,
@@ -744,6 +748,10 @@ cluster_formation.node_cleanup.only_log_warning = true
 cluster_partition_handling = autoheal
 
 queue_master_locator = min-masters
+
+# Log to console for pod logging
+log.console = true
+log.file = false
 """
         logger.info("Pushing new rabbitmq.conf")
         container.push(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -76,7 +76,7 @@ class TestCharm(unittest.TestCase):
                 "rabbitmq": {
                     "override": "replace",
                     "summary": "RabbitMQ Server",
-                    "command": "rabbitmq-server",
+                    "command": "/usr/lib/rabbitmq/bin/rabbitmq-server",
                     "startup": "enabled",
                     "user": "rabbitmq",
                     "group": "rabbitmq",


### PR DESCRIPTION
As RabbitMQ is running under Pebble inside of a container, make sure all log output goes to the console so it can easily be accessed and collecting into observability solutions.