### PR TITLE
Filter queue lists to quorom queues only

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -395,7 +395,7 @@ class RabbitMQOperatorCharm(CharmBase):
         """Grow any undersized queues onto unit."""
         api = self._get_admin_api()
         joining_node = self.generate_nodename(unit)
-        queue_members = [len(q["members"]) for q in api.list_queues()]
+        queue_members = [len(q["members"]) for q in api.list_quorum_queues()]
         if not queue_members:
             logging.debug("No queues found, queue growth skipped")
         queue_members.sort()
@@ -808,7 +808,7 @@ USE_LONGNAME=true
         api = self._get_admin_api()
         undersized_queues = [
             q
-            for q in api.list_queues()
+            for q in api.list_quorum_queues()
             if len(q["members"]) < self.min_replicas()
         ]
         return undersized_queues

--- a/src/rabbit_extended_api.py
+++ b/src/rabbit_extended_api.py
@@ -19,6 +19,10 @@
 
 import json
 import urllib
+from typing import (
+    Dict,
+    List,
+)
 
 import rabbitmq_admin
 
@@ -27,8 +31,14 @@ class ExtendedAdminApi(rabbitmq_admin.AdminAPI):
     """Extend rabbitmq_admin.AdminAPI to cover missing endpoints the charm needs."""
 
     def list_queues(self):
-        """A list of nodes in the RabbitMQ cluster."""
+        """A list of queues."""
         return self._api_get("/api/queues")
+
+    def list_quorum_queues(self) -> List[Dict]:
+        """A list of quorum queues."""
+        return [
+            q for q in self._api_get("/api/queues") if q["type"] == "quorum"
+        ]
 
     def get_queue(self, vhost, queue):
         """A list of nodes in the RabbitMQ cluster."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -242,14 +242,16 @@ class TestCharm(unittest.TestCase):
             "vhost": "openstack",
             "members": ["node1", "node2", "node3"],
         }
-        self.mock_admin_api.list_queues.return_value = [queue_one_member]
+        self.mock_admin_api.list_quorum_queues.return_value = [
+            queue_one_member
+        ]
         self.harness.charm.grow_queues_onto_unit("unit/1")
         self.mock_admin_api.grow_queue.assert_called_once_with(
             "rabbit@unit-1.rabbitmq-k8s-endpoints", "all"
         )
 
         self.mock_admin_api.grow_queue.reset_mock()
-        self.mock_admin_api.list_queues.return_value = [
+        self.mock_admin_api.list_quorum_queues.return_value = [
             queue_two_member,
             queue_three_member,
         ]
@@ -259,7 +261,7 @@ class TestCharm(unittest.TestCase):
         )
 
         self.mock_admin_api.grow_queue.reset_mock()
-        self.mock_admin_api.list_queues.return_value = [
+        self.mock_admin_api.list_quorum_queues.return_value = [
             queue_one_member,
             queue_two_member,
             queue_three_member,


### PR DESCRIPTION
The charm only manages the new quorom queues, so when managing queues only act on quorom queues.