### PR TITLE
Cleanup accounts when amqp is removed

### DIFF
--- a/src/interface_rabbitmq_peers.py
+++ b/src/interface_rabbitmq_peers.py
@@ -169,6 +169,11 @@ class RabbitMQOperatorPeers(Object):
         logging.debug(f"Storing password for {username}")
         self.peers_rel.data[self.peers_rel.app][username] = password
 
+    def delete_user(self, username: str):
+        """Delete username from application data."""
+        if username in self.peers_rel.data[self.peers_rel.app]:
+            del self.peers_rel.data[self.peers_rel.app][username]
+
     def set_nodename(self, nodename: str):
         """Advertise nodename to peers."""
         logging.debug(f"Setting nodename {nodename}")


### PR DESCRIPTION
Catch AMQP relation broken event and emit
event to the provider.
Handle emitted event in rabbitmq and delete
the user in rabbitmq and peer application data.

Format rabbitmq library.

Fixes: #2039545