### PR TITLE
set ownership of /var/lib/rabbitmq to rabbitmq user

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -66,6 +66,7 @@ class TestCharm(unittest.TestCase):
         """Test pebble handler."""
         # self.harness.charm._render_and_push_config_files = Mock()
         # self.harness.charm._render_and_push_plugins = Mock()
+        self.harness.charm._set_ownership_on_data_dir = Mock()
         # Check the initial Pebble plan is empty
         self.harness.set_can_connect("rabbitmq", True)
         initial_plan = self.harness.get_container_pebble_plan("rabbitmq")


### PR DESCRIPTION
For certain storage providers, the mounted directory /var/lib/rabbitmq is created with root:root as owner. This causes issues to start the rabbitmq server.
Change ownership of /var/lib/rabbitmq to rabbitmq:rabbitmq.