### PR TITLE
Implement ensure-ha

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -22,7 +22,7 @@ get-service-account:
 
 ensure-queue-ha:
   description: |
-    Check for queues that have insufficent memebers for high
+    Check for queues that have insufficent members for high
     availability and, if possible, add members to them.
   params:
     dry-run:

--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,7 @@ options:
     default: 3
     description: Minimum number of queues replicas, set to 0 to disable charm automatically managing queue replicas
     type: int
+  auto-ha-frequency:
+    default: 30
+    description: Frequency in minutes to check for queues that need HA members added
+    type: int

--- a/src/interface_rabbitmq_peers.py
+++ b/src/interface_rabbitmq_peers.py
@@ -131,7 +131,7 @@ class RabbitMQOperatorPeers(Object):
     def on_broken(self, event):
         """Relation broken event handler."""
         logging.debug("RabbitMQOperatorPeers on_broken")
-        self.on.gonewaway.emit()
+        self.on.goneaway.emit()
 
     def on_departed(self, event):
         """Relation broken event handler."""


### PR DESCRIPTION
Implement ensure-ha utility both as an action and as an automated operation.

Use action when queue management is disabled, or auto-ha-frequency is too long.

Ensure-ha will add members to queue based on how many queues a member already has, to try to balance number of queues in larger clusters.