### PR TITLE
Update upstream-source

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
   rabbitmq-image:
     type: oci-image
     description: OCI image for rabbitmq
-    upstream-source: ghcr.io/openstack-snaps/rabbitmq:3.12.1
+    upstream-source: ghcr.io/canonical/rabbitmq:3.12.1
 
 storage:
   rabbitmq-data:


### PR DESCRIPTION
Update upstream source to target rocks produced by https://github.com/canonical/ubuntu-openstack-rocks/.