### PR TITLE
Run release job on 24.04

### DIFF
--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -37,7 +37,7 @@ jobs:
     needs:
       - lint
       - unit-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The pack action is performed in destructive mode, which will use the current host to pack the charm. Therefore the host must match the charm base.