### PR TITLE
Add requires to Notifier service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -306,6 +306,9 @@ class RabbitMQOperatorCharm(CharmBase):
                     "summary": "Pebble notifier",
                     "command": "/usr/bin/notifier",
                     "startup": "enabled",
+                    # Workaround to avoid bug
+                    # https://github.com/canonical/pebble/issues/525
+                    "requires": [RABBITMQ_SERVICE],
                 },
             },
         }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -90,6 +90,7 @@ class TestCharm(unittest.TestCase):
                     "override": "replace",
                     "startup": "enabled",
                     "summary": "Pebble notifier",
+                    "requires": ["rabbitmq"],
                 },
                 "epmd": {
                     "override": "replace",


### PR DESCRIPTION
Autostart of mix of service dependencies
resulted in panic mode pebble, see bug [1]

As a workaround, add Requires to notifier
service definition.

[1] https://github.com/canonical/pebble/issues/525