### PR TITLE
Reconcile LoadBalancer service on config-changed

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -135,6 +135,7 @@ class RabbitMQOperatorCharm(CharmBase):
         # NOTE(jamespage): This should become part of what Juju
         # does at some point in time.
         self.framework.observe(self.on.install, self._reconcile_lb)
+        self.framework.observe(self.on.config_changed, self._reconcile_lb)
         self.framework.observe(
             self.on.rabbitmq_pebble_ready, self._on_config_changed
         )


### PR DESCRIPTION
Ensure that the LoadBalancer service definition is updated/created on config-changed events.

This covers upgrade from previous versions of the charm which directly patched the Juju created service definition.