### PR TITLE
Add `loadbalancer_annotations` config option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,6 +21,19 @@ config:
       default: 30
       description: Frequency in minutes to check for queues that need HA members added
       type: int
+    loadbalancer_annotations:
+      description: |
+        A comma-separated list of annotations to apply to the LoadBalancer service.
+        The format should be: `key1=value1,key2=value2,key3=value3`.
+        These annotations are passed directly to the Kubernetes LoadBalancer service,
+        enabling customization for specific cloud provider settings or integrations.
+
+        Example:
+          "external-dns.alpha.kubernetes.io/hostname=example.com,service.beta.kubernetes.io/aws-load-balancer-type=nlb"
+
+        Ensure the annotations are correctly formatted and adhere to Kubernetes' syntax and character set : https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+        Invalid values will result in LoadBalancer being removed and all previously set annotations will be lost.
+      type: string
 
 actions:
   get-operator-info:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -522,3 +522,66 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.on.update_status.emit()
         self.harness.charm._publish_relation_data.assert_called_once()
         self.harness.charm.get_hostname.assert_not_called()
+
+    def test_lb_annotations(self):
+        """Test the _loadbalancer_annotations property."""
+        test_cases = [
+            ("key1=value1,key2=value2", {"key1": "value1", "key2": "value2"}),
+            ("", {}),
+            (
+                "key1=value1,key_2=value2,key-3=value3,",
+                {"key1": "value1", "key_2": "value2", "key-3": "value3"},
+            ),
+            (
+                "key1=value1,key2=value2,key3=value3",
+                {"key1": "value1", "key2": "value2", "key3": "value3"},
+            ),
+            ("example.com/key=value", {"example.com/key": "value"}),
+            (
+                "prefix1/key=value1,prefix2/another-key=value2",
+                {"prefix1/key": "value1", "prefix2/another-key": "value2"},
+            ),
+            (
+                "key=value,key.sub-key=value-with-hyphen",
+                {"key": "value", "key.sub-key": "value-with-hyphen"},
+            ),
+            # Invalid cases
+            (
+                "key1=value1,key2=value2,key=value3,key4=",
+                None,
+            ),  # Missing value for key4
+            (
+                "kubernetes.io/description=this-is-valid,custom.io/key=value",
+                None,
+            ),  # Reserved prefix used
+            ("key1=value1,key2", None),
+            (
+                "key1=value1,example..com/key2=value2",
+                None,
+            ),  # Invalid domain format (double dot)
+            ("key1=value1,key=value2,key3=", None),  # Trailing equals for key3
+            ("key1=value1,=value2", None),  # Missing key
+            ("key1=value1,key=val=ue2", None),  # Extra equals in value
+            (
+                "a" * 256 + "=value",
+                None,
+            ),  # Key exceeds max length (256 characters)
+            ("key@=value", None),  # Invalid character in key
+            ("key. =value", None),  # Space in key
+            ("key,value", None),  # Missing '=' delimiter
+            ("kubernetes/description=", None),  # Key with no value
+        ]
+
+        for annotations, expected_result in test_cases:
+            with self.subTest(
+                annotations=annotations, expected_result=expected_result
+            ):
+                # Update the config with the test annotation string
+                self.harness.update_config(
+                    {"loadbalancer_annotations": annotations}
+                )
+                # Check if the _loadbalancer_annotations property returns the expected result
+                self.assertEqual(
+                    self.harness.charm._loadbalancer_annotations,
+                    expected_result,
+                )


### PR DESCRIPTION
This PR adds the config option `loadbalancer_annotations`, which allows the user to configure a comma-separated list of annotations to apply to the LoadBalancer service to configure the LoadBalancer service inside Kubernetes.
